### PR TITLE
Update launchers to use image v05.

### DIFF
--- a/start-hrwros-nvidia.desktop
+++ b/start-hrwros-nvidia.desktop
@@ -2,7 +2,7 @@
 Encoding=UTF-8
 Name=HRWROS MOOC Environment (NVIDIA)
 Comment=Startup the environment for HRWROS for computers with NVIDIA graphics cards.
-Exec=gnome-terminal -e 'bash -c "singularity shell --nv ${HOME}/Downloads/hrwros_kinetic_desktop_v0.3.simg"' --class=hrwros_mooc_class
+Exec=gnome-terminal -e 'bash -c "singularity shell --nv ${HOME}/Downloads/hrwros-05.simg"' --class=hrwros_mooc_class
 Icon=hrwros-mooc-icon.jpg
 Terminal=false
 Categories=ROS;MOOC;HRWROS;

--- a/start-hrwros.desktop
+++ b/start-hrwros.desktop
@@ -2,7 +2,7 @@
 Encoding=UTF-8
 Name=HRWROS MOOC Environment (non-NVIDIA)
 Comment=Startup the environment for HRWROS (non-NVIDIA computers).
-Exec=gnome-terminal -e 'bash -c "singularity shell ${HOME}/Downloads/hrwros_kinetic_desktop_v0.3.simg"' --class=hrwros_mooc_class
+Exec=gnome-terminal -e 'bash -c "singularity shell ${HOME}/Downloads/hrwros-05.simg"' --class=hrwros_mooc_class
 Icon=hrwros-mooc-icon.jpg
 Terminal=false
 Categories=ROS;MOOC;HRWROS;


### PR DESCRIPTION
As per subject.

This depends on rosin-project/mooc_hrwros_singularity#5.
