### PR TITLE
🐛 -e deprecated & /usr/bin -> /usr/local/bin

### DIFF
--- a/start-hrwros-nvidia.desktop
+++ b/start-hrwros-nvidia.desktop
@@ -3,7 +3,7 @@ Encoding=UTF-8
 Name=HRWROS (Nvidia)
 Comment=Startup the environment for HRWROS for computers with NVIDIA graphics cards.
 Icon=hrwros-mooc-icon-nv.png
-Exec=gnome-terminal -- /bin/bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p --nv $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class_nv
+Exec=gnome-terminal --class=hrwros_mooc_class_nv -- /bin/bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p --nv $(xdg-user-dir DOWNLOAD)/hrwros-09.simg"
 Terminal=false
 Categories=ROS;MOOC;HRWROS;
 Type=Application
@@ -11,5 +11,5 @@ StartupWMClass=hrwros_mooc_class_nv
 Actions=new-ccs
 [Desktop Action new-ccs]
 Name=New CCS (Nvidia)
-Exec=gnome-terminal -- /bin/bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p --nv $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class_nv
+Exec=gnome-terminal --class=hrwros_mooc_class_nv -- /bin/bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p --nv $(xdg-user-dir DOWNLOAD)/hrwros-09.simg"
 

--- a/start-hrwros-nvidia.desktop
+++ b/start-hrwros-nvidia.desktop
@@ -3,9 +3,7 @@ Encoding=UTF-8
 Name=HRWROS (Nvidia)
 Comment=Startup the environment for HRWROS for computers with NVIDIA graphics cards.
 Icon=hrwros-mooc-icon-nv.png
-Exec=gnome-terminal -- bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /
-usr/local/bin/singularity shell -p --nv $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_cla
-ss_nv
+Exec=gnome-terminal -- bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p --nv $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class_nv
 Terminal=false
 Categories=ROS;MOOC;HRWROS;
 Type=Application
@@ -13,7 +11,5 @@ StartupWMClass=hrwros_mooc_class_nv
 Actions=new-ccs
 [Desktop Action new-ccs]
 Name=New CCS (Nvidia)
-Exec=gnome-terminal -- bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /
-usr/local/bin/singularity shell -p --nv $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_cla
-ss_nv
+Exec=gnome-terminal -- bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p --nv $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class_nv
 

--- a/start-hrwros-nvidia.desktop
+++ b/start-hrwros-nvidia.desktop
@@ -2,8 +2,10 @@
 Encoding=UTF-8
 Name=HRWROS (Nvidia)
 Comment=Startup the environment for HRWROS for computers with NVIDIA graphics cards.
-Exec=gnome-terminal -e '/bin/bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p --nv $(xdg-user-dir DOWNLOAD)/hrwros-09.simg"' --class=hrwros_mooc_class_nv
 Icon=hrwros-mooc-icon-nv.png
+Exec=gnome-terminal -- bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /
+usr/local/bin/singularity shell -p --nv $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_cla
+ss_nv
 Terminal=false
 Categories=ROS;MOOC;HRWROS;
 Type=Application
@@ -11,4 +13,7 @@ StartupWMClass=hrwros_mooc_class_nv
 Actions=new-ccs
 [Desktop Action new-ccs]
 Name=New CCS (Nvidia)
-Exec=gnome-terminal -e '/bin/bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p --nv $(xdg-user-dir DOWNLOAD)/hrwros-09.simg"' --class=hrwros_mooc_class_nv
+Exec=gnome-terminal -- bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /
+usr/local/bin/singularity shell -p --nv $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_cla
+ss_nv
+

--- a/start-hrwros-nvidia.desktop
+++ b/start-hrwros-nvidia.desktop
@@ -11,5 +11,5 @@ StartupWMClass=hrwros_mooc_class_nv
 Actions=new-ccs
 [Desktop Action new-ccs]
 Name=New CCS (Nvidia)
-Exec=gnome-terminal -- bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p --nv $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class_nv
+Exec=gnome-terminal -- /bin/bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p --nv $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class_nv
 

--- a/start-hrwros-nvidia.desktop
+++ b/start-hrwros-nvidia.desktop
@@ -3,7 +3,7 @@ Encoding=UTF-8
 Name=HRWROS (Nvidia)
 Comment=Startup the environment for HRWROS for computers with NVIDIA graphics cards.
 Icon=hrwros-mooc-icon-nv.png
-Exec=gnome-terminal -- bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p --nv $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class_nv
+Exec=gnome-terminal -- /bin/bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p --nv $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class_nv
 Terminal=false
 Categories=ROS;MOOC;HRWROS;
 Type=Application

--- a/start-hrwros.desktop
+++ b/start-hrwros.desktop
@@ -3,7 +3,7 @@ Encoding=UTF-8
 Name=HRWROS
 Comment=Startup the environment for HRWROS (non-NVIDIA computers).
 Icon=hrwros-mooc-icon.png
-Exec=gnome-terminal -- bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class
+Exec=gnome-terminal -- /bin/bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class
 Terminal=false
 Categories=ROS;MOOC;HRWROS;
 Type=Application

--- a/start-hrwros.desktop
+++ b/start-hrwros.desktop
@@ -2,8 +2,9 @@
 Encoding=UTF-8
 Name=HRWROS
 Comment=Startup the environment for HRWROS (non-NVIDIA computers).
-Exec=gnome-terminal -e '/bin/bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p $(xdg-user-dir DOWNLOAD)/hrwros-09.simg"' --class=hrwros_mooc_class
 Icon=hrwros-mooc-icon.png
+Exec=gnome-terminal -- bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /
+usr/local/bin/singularity shell -p $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class
 Terminal=false
 Categories=ROS;MOOC;HRWROS;
 Type=Application
@@ -11,5 +12,6 @@ StartupWMClass=hrwros_mooc_class
 Actions=new-ccs
 [Desktop Action new-ccs]
 Name=New CCS
-Exec=gnome-terminal -e '/bin/bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p $(xdg-user-dir DOWNLOAD)/hrwros-09.simg"' --class=hrwros_mooc_class
+Exec=gnome-terminal -- bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /
+usr/local/bin/singularity shell -p $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class
 

--- a/start-hrwros.desktop
+++ b/start-hrwros.desktop
@@ -3,7 +3,7 @@ Encoding=UTF-8
 Name=HRWROS
 Comment=Startup the environment for HRWROS (non-NVIDIA computers).
 Icon=hrwros-mooc-icon.png
-Exec=gnome-terminal -- /bin/bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class
+Exec=gnome-terminal --class=hrwros_mooc_class -- /bin/bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p $(xdg-user-dir DOWNLOAD)/hrwros-09.simg"
 Terminal=false
 Categories=ROS;MOOC;HRWROS;
 Type=Application
@@ -11,5 +11,5 @@ StartupWMClass=hrwros_mooc_class
 Actions=new-ccs
 [Desktop Action new-ccs]
 Name=New CCS
-Exec=gnome-terminal -- /bin/bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class
+Exec=gnome-terminal --class=hrwros_mooc_class -- /bin/bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p $(xdg-user-dir DOWNLOAD)/hrwros-09.simg"
 

--- a/start-hrwros.desktop
+++ b/start-hrwros.desktop
@@ -3,8 +3,7 @@ Encoding=UTF-8
 Name=HRWROS
 Comment=Startup the environment for HRWROS (non-NVIDIA computers).
 Icon=hrwros-mooc-icon.png
-Exec=gnome-terminal -- bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /
-usr/local/bin/singularity shell -p $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class
+Exec=gnome-terminal -- bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class
 Terminal=false
 Categories=ROS;MOOC;HRWROS;
 Type=Application
@@ -12,6 +11,5 @@ StartupWMClass=hrwros_mooc_class
 Actions=new-ccs
 [Desktop Action new-ccs]
 Name=New CCS
-Exec=gnome-terminal -- bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /
-usr/local/bin/singularity shell -p $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class
+Exec=gnome-terminal -- bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class
 

--- a/start-hrwros.desktop
+++ b/start-hrwros.desktop
@@ -11,5 +11,5 @@ StartupWMClass=hrwros_mooc_class
 Actions=new-ccs
 [Desktop Action new-ccs]
 Name=New CCS
-Exec=gnome-terminal -- bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class
+Exec=gnome-terminal -- /bin/bash -c "/bin/mkdir -p /tmp/hrwros_run/dconf && XDG_RUNTIME_DIR=/tmp/hrwros_run /usr/bin/singularity shell -p $(xdg-user-dir DOWNLOAD)/hrwros-09.simg" --class=hrwros_mooc_class
 


### PR DESCRIPTION
I am following the [course](https://learning.edx.org/course/course-v1:DelftX+ROS1x+1T2020/block-v1:DelftX+ROS1x+1T2020+type@sequential+block@1e69cfa733964152b8d34232dedd7d2d/block-v1:DelftX+ROS1x+1T2020+type@vertical+block@a3de6a135b5843e5b0b285dff35bf8ed) and I encountered an error when running singularity in ubuntu 18.04. 

It seems that `gnome-terminal -e` is deprecated and was substituted with `gnome-terminal -- `. 

Also, when running hrwros I get this error:

```
ERROR  : Failed to mount squashfs image in (read only): Invalid argument
```
Apparently this is due to ubuntu 18.04 using the version [2.4.2](https://packages.ubuntu.com/search?suite=bionic&arch=any&searchon=names&keywords=singularity) of singulary-containter and it seems that versions <3.0.0 are not supported anymore. See: https://github.com/hpcng/singularity/issues/5482

A solution is to manually install singularity as detailed in this [link](https://github.com/hpcng/singularity/blob/master/INSTALL.md).
When building following the instructions singularity is placed in `/usr/local/bin` that is why I also proposed this change. It is also possible to manually set the place where it gets installed, so if you find better I can change the commit to keep using `/usr/bin`